### PR TITLE
Fix dead link 0.0.0.0:port to a valid link if the listening ip 0.0.0.…

### DIFF
--- a/OpenHardwareMonitor/UI/AboutBox.Designer.cs
+++ b/OpenHardwareMonitor/UI/AboutBox.Designer.cs
@@ -34,7 +34,6 @@ namespace OpenHardwareMonitor.UI
             this.lblVersion = new System.Windows.Forms.Label();
             this.projectLinkLabel = new System.Windows.Forms.LinkLabel();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.licenseLinkLabel = new System.Windows.Forms.LinkLabel();
             ((System.ComponentModel.ISupportInitialize) (this.picLogo)).BeginInit();
             this.SuspendLayout();
             // 
@@ -88,7 +87,7 @@ namespace OpenHardwareMonitor.UI
             // projectLinkLabel
             // 
             this.projectLinkLabel.AutoSize = true;
-            this.projectLinkLabel.Location = new System.Drawing.Point(164, 80);
+            this.projectLinkLabel.Location = new System.Drawing.Point(74, 80);
             this.projectLinkLabel.Margin = new System.Windows.Forms.Padding(0);
             this.projectLinkLabel.Name = "projectLinkLabel";
             this.projectLinkLabel.Size = new System.Drawing.Size(82, 13);
@@ -107,18 +106,6 @@ namespace OpenHardwareMonitor.UI
             this.flowLayoutPanel1.Size = new System.Drawing.Size(0, 0);
             this.flowLayoutPanel1.TabIndex = 8;
             // 
-            // licenseLinkLabel
-            // 
-            this.licenseLinkLabel.AutoSize = true;
-            this.licenseLinkLabel.Location = new System.Drawing.Point(25, 80);
-            this.licenseLinkLabel.Margin = new System.Windows.Forms.Padding(0);
-            this.licenseLinkLabel.Name = "licenseLinkLabel";
-            this.licenseLinkLabel.Size = new System.Drawing.Size(107, 13);
-            this.licenseLinkLabel.TabIndex = 9;
-            this.licenseLinkLabel.TabStop = true;
-            this.licenseLinkLabel.Text = "Licensing Information";
-            this.licenseLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
-            // 
             // AboutBox
             // 
             this.AcceptButton = this.okButton;
@@ -127,7 +114,6 @@ namespace OpenHardwareMonitor.UI
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(359, 115);
-            this.Controls.Add(this.licenseLinkLabel);
             this.Controls.Add(this.flowLayoutPanel1);
             this.Controls.Add(this.projectLinkLabel);
             this.Controls.Add(this.lblVersion);
@@ -156,6 +142,5 @@ namespace OpenHardwareMonitor.UI
         private System.Windows.Forms.Label lblVersion;
         private System.Windows.Forms.LinkLabel projectLinkLabel;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
-        private System.Windows.Forms.LinkLabel licenseLinkLabel;
     }
 }

--- a/OpenHardwareMonitor/UI/AboutBox.cs
+++ b/OpenHardwareMonitor/UI/AboutBox.cs
@@ -24,8 +24,6 @@ public sealed partial class AboutBox : Form
         picLogo.SizeMode = PictureBoxSizeMode.StretchImage;
         projectLinkLabel.Links.Remove(projectLinkLabel.Links[0]);
         projectLinkLabel.Links.Add(0, projectLinkLabel.Text.Length, $"https://github.com/{Updater.ApplicationCompany}/{Updater.ApplicationName}");
-        licenseLinkLabel.Links.Remove(licenseLinkLabel.Links[0]);
-        licenseLinkLabel.Links.Add(0, licenseLinkLabel.Text.Length, "https://www.gnu.org/licenses/gpl-3.0.html");
         Theme.Current.Apply(this);
     }
 


### PR DESCRIPTION
1. Fix bug：
When "0.0.0.0" is selected as network inteface in the Set Port Form, the web server link will point to "0.0.0.0:8085" which is not a valid link. Modify it to first actual network interface IP instead.
2. The "Open" menu item of the MainForm and the web server link of the Set Port Form are disabled if the web server is not running.

<img width="880" height="522" alt="image" src="https://github.com/user-attachments/assets/ede5390c-21bd-4726-8d9e-c89297a97c97" />

 